### PR TITLE
Marshal chain state under lock

### DIFF
--- a/tevm/evm.go
+++ b/tevm/evm.go
@@ -829,3 +829,30 @@ func (c *Chain) Seal() {
 		Timestamp:       seth.Uint64(time.Now().Unix()),
 	}
 }
+
+// MarshalJSON implements json.Marshaler.
+func (c *Chain) MarshalJSON() ([]byte, error) {
+	c.mu.Lock()
+	b, err := json.Marshal(&struct {
+		State      State
+		Block2snap map[int64]int
+	}{c.State, c.block2snap})
+	c.mu.Unlock()
+	return b, err
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (c *Chain) UnmarshalJSON(b []byte) error {
+	var s struct {
+		State      State
+		Block2snap map[int64]int
+	}
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.State = s.State
+	c.block2snap = s.Block2snap
+	c.mu.Unlock()
+	return nil
+}

--- a/tevm/evm_test.go
+++ b/tevm/evm_test.go
@@ -122,19 +122,19 @@ func TestChainSerialization(t *testing.T) {
 	*chain.State.Pending.Number += 42
 	chain.Seal()
 
-	b, err := json.Marshal(chain.State)
+	b, err := json.Marshal(chain)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	state := new(State)
+	chain2 := new(Chain)
 
-	if err := json.Unmarshal(b, state); err != nil {
+	if err := json.Unmarshal(b, chain2); err != nil {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(&chain.State, state) {
-		t.Fatal("chain state did not match:\n", &chain.State, "\n", state)
+	if !reflect.DeepEqual(chain, chain2) {
+		t.Fatal("chain state did not match:\n", chain, "\n", chain2)
 	}
 }
 


### PR DESCRIPTION
This does marshaling of the chain state under a lock to prevent races. This also marshals the block2snap map.