### PR TITLE
fix broken RPCTransport

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ var ErrNotFound = errors.New("seth: not found")
 // represent a pending rpc request
 type pending struct {
 	notify chan struct{}
-	res    interface{}
+	res    *RPCResponse
 	err    error
 }
 
@@ -62,7 +62,7 @@ func (t *RPCTransport) background(conn io.ReadWriteCloser) {
 		} else if bytes.Equal(t.res.Result, rawnull) {
 			p.err = ErrNotFound
 		} else {
-			p.err = json.Unmarshal(t.res.Result, p.res)
+			*p.res = t.res
 		}
 		close(p.notify)
 	}


### PR DESCRIPTION
Commit be7307f2d7e76586bfce9f04bedc78f208b93df6 broke `seth.RPCTransport`. In short, the patch changed the responsibility of unmarshaling the body of the response into `Execute` without moving the corresponding code from `background()`. This change is the minimal fix for that regression; I expect to find a cleaner solution shortly.

CC @jperson 