### PR TITLE
add tevm "forking"

### DIFF
--- a/send.go
+++ b/send.go
@@ -264,7 +264,7 @@ func (c *Client) StorageAt(addr *Address, offset *Hash, block int64) (Hash, erro
 	case -1:
 		buf3 = rawlatest
 	default:
-		buf3, _ = json.Marshal(block)
+		buf3 = itox(block)
 	}
 	var out Hash
 	err := c.Do("eth_getStorageAt", []json.RawMessage{buf, buf2, buf3}, &out)

--- a/seth.go
+++ b/seth.go
@@ -451,6 +451,30 @@ var rawpending = json.RawMessage(`"pending"`)
 var rawlatest = json.RawMessage(`"latest"`)
 var rawnull = json.RawMessage("null")
 
+// GetNonceAt gets the account nonce for a specific address
+// and at a specific block number.
+func (c *Client) GetNonceAt(addr *Address, blocknum int64) (int64, error) {
+	var params [2]json.RawMessage
+	buf, _ := json.Marshal(addr)
+	params[0] = buf
+	params[1] = itox(blocknum)
+	var num Int
+	err := c.Do("eth_getTransactionCount", params[:], &num)
+	return num.Int64(), err
+}
+
+// GetBalanceAt gets the balance for a specific address
+// and at a specific block number.
+func (c *Client) GetBalanceAt(addr *Address, blocknum int64) (Int, error) {
+	var params [2]json.RawMessage
+	buf, _ := json.Marshal(addr)
+	params[0] = buf
+	params[1] = itox(blocknum)
+	wei := Int{}
+	err := c.Do("eth_getBalance", params[:], &wei)
+	return wei, err
+}
+
 // GetBalance gets the balance of an address in wei at the latest block.
 func (c *Client) GetBalance(addr *Address) (Int, error) {
 	params := []json.RawMessage{nil, rawlatest}
@@ -577,6 +601,19 @@ type Receipt struct {
 // Threw returns whether the transaction threw.
 func (r *Receipt) Threw() bool {
 	return r.Status == 0
+}
+
+func (c *Client) GetCodeAt(addr *Address, blocknum int64) ([]byte, error) {
+	var params [2]json.RawMessage
+	buf, _ := json.Marshal(addr)
+	params[0] = buf
+	params[1] = itox(blocknum)
+	var out Data
+	err := c.Do("eth_getCode", params[:], &out)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(out), nil
 }
 
 func (c *Client) GetCode(addr *Address) ([]byte, error) {

--- a/seth_test.go
+++ b/seth_test.go
@@ -160,26 +160,30 @@ func TestReceipt(t *testing.T) {
 		ugly, _ = ParseHash("0xf00ba4f00ba4f00ba4f00ba4f00ba4f00ba4f00ba4f00ba4f00ba4f00ba4f00b")
 	)
 
-	c := NewHTTPClient("https://api.myetherapi.com/eth")
+	for _, c := range []*Client{
+		NewHTTPClient("https://api.myetherapi.com/eth"),
+		NewClientTransport(InfuraTransport{}),
+	} {
 
-	if r, err := c.GetReceipt(good); err != nil {
-		t.Error(err)
-	} else if r == nil {
-		t.Error("receipt not found")
-	} else if r.Threw() {
-		t.Error("receipt indicates failure")
-	}
+		if r, err := c.GetReceipt(good); err != nil {
+			t.Error(err)
+		} else if r == nil {
+			t.Error("receipt not found")
+		} else if r.Threw() {
+			t.Error("receipt indicates failure")
+		}
 
-	if r, err := c.GetReceipt(bad); err != nil {
-		t.Error(err)
-	} else if r == nil {
-		t.Error("receipt not found")
-	} else if !r.Threw() {
-		t.Error("receipt indicates success")
-	}
+		if r, err := c.GetReceipt(bad); err != nil {
+			t.Error(err)
+		} else if r == nil {
+			t.Error("receipt not found")
+		} else if !r.Threw() {
+			t.Error("receipt indicates success")
+		}
 
-	if _, err := c.GetReceipt(ugly); err != ErrNotFound {
-		t.Error("expected not found, but got:", err)
+		if _, err := c.GetReceipt(ugly); err != ErrNotFound {
+			t.Error("expected not found, but got:", err)
+		}
 	}
 }
 

--- a/tevm/evm_test.go
+++ b/tevm/evm_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/json"
+	"math/big"
 	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/newalchemylimited/seth"
+	"github.com/newalchemylimited/seth/cc"
 )
 
 func tracefn(t *testing.T) func(s string, args ...interface{}) {
@@ -201,5 +203,26 @@ func TestCreateAt(t *testing.T) {
 	code = bundle.Contract("Bad").Code
 	if err := chain.CreateAt(addr, &me, code); err == nil {
 		t.Fatal("expected error, got nothing")
+	}
+}
+
+func TestForkedChain(t *testing.T) {
+	chain := NewFork(seth.NewClientTransport(seth.InfuraTransport{}), 4876654)
+	me := chain.NewAccount(1)
+
+	// Check that the total supply of OMG is 140245398245132780789239631
+
+	omg, _ := cc.CurrencyByName("OMG")
+	var out, ts big.Int
+	ts.SetString("140245398245132780789239631", 10)
+
+	ret, err := chain.StaticCall(&me, omg.Addr(), "totalSupply()")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out.SetBytes(ret)
+
+	if out.Cmp(&ts) != 0 {
+		t.Fatalf("%d != %d", &out, &ts)
 	}
 }


### PR DESCRIPTION
This PR adds a "fallback chain" for `tevm.Chain` that allows `vm.StateDB` calls to be proxied to a `*seth.Client` if the account or state requested isn't present in the in-memory state.

Practically speaking, this feature is really a way to create a cheap "fork" of an existing chain without actually copying any data, and without having to know in advance which parts of the chain you will access.