### PR TITLE
add experimental tevmd fork option

### DIFF
--- a/tevm/tevmd/main.go
+++ b/tevm/tevmd/main.go
@@ -4,7 +4,9 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"strconv"
 
+	"github.com/newalchemylimited/seth"
 	"github.com/newalchemylimited/seth/tevm"
 )
 
@@ -16,7 +18,23 @@ func init() {
 
 func main() {
 	flag.Parse()
-	c := tevm.NewChain()
+
+	var c *tevm.Chain
+	args := flag.Args()
+	if len(args) > 0 && args[0] == "fork" {
+		if len(args) != 2 {
+			log.Fatalln("expected args 'tevmd fork <blocknum>'")
+		}
+		bn, err := strconv.ParseInt(args[1], 10, 64)
+		if err != nil {
+			log.Fatalf("can't parse %q as block number: %s", args[1], err)
+		}
+		log.Println("forking main chain at block %d", bn)
+		c = tevm.NewFork(seth.NewClientTransport(seth.InfuraTransport{}), bn)
+	} else {
+		c = tevm.NewChain()
+	}
+
 	acct := c.NewAccount(10)
 	log.Println("default account:", acct.String())
 	log.Printf("binding to %s...", addr)


### PR DESCRIPTION
Allow for running tevmd as `tevmd fork <blocknum>` to get mainnet data.