### PR TITLE
add (*tevm.Chain).Copy()

### DIFF
--- a/tevm/evm.go
+++ b/tevm/evm.go
@@ -428,6 +428,7 @@ func (s *State) atSnap(n int, dst *State) {
 		return
 	}
 	ns := s.Snapshots[n]
+	dst.Fallback = s.Fallback
 	dst.Trace = s.Trace
 	dst.Refund = s.Refund
 	dst.Accounts = s.Accounts.CopyAt(ns.Accounts)
@@ -470,6 +471,20 @@ type Chain struct {
 	State      State
 	block2snap map[int64]int
 	mu         sync.Mutex
+}
+
+// Copy returns a new logical copy of the chain.
+// Copy avoids making a deep copy of the state.
+func (c *Chain) Copy() *Chain {
+	cc := new(Chain)
+
+	// snapshot the current chain state
+	// and grab a logical copy of the snapshot
+	c.State.atSnap(((*gethState)(&c.State)).Snapshot(), &cc.State)
+
+	p := *c.State.Pending
+	cc.State.Pending = &p
+	return cc
 }
 
 // AtBlock returns the chain state at a given

--- a/tevm/evm_test.go
+++ b/tevm/evm_test.go
@@ -228,4 +228,23 @@ func TestForkedChain(t *testing.T) {
 	if out.Cmp(&ts) != 0 {
 		t.Fatalf("%d != %d", &out, &ts)
 	}
+
+	chain2 := chain.Copy()
+
+	me2 := chain2.NewAccount(1)
+
+	ret, err = chain2.StaticCall(&me2, omg.Addr(), "totalSupply()")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out.SetBytes(ret)
+
+	if out.Cmp(&ts) != 0 {
+		t.Fatalf("%d != %d", &out, &ts)
+	}
+
+	bal := chain.BalanceOf(&me2)
+	if bal.Sign() != 0 {
+		t.Errorf("non-zero balance (%d) on the other side of the chain copy...?", bal)
+	}
 }


### PR DESCRIPTION
Being able to produce a logical copy of the chain state is useful when you have tests that all require the chain to be populated with the same state. Rather than setting up the state a bunch of times, you can set it up once and then clone it for each test. (For tests that rely on tevm forks, this performance optimization is huge.)