### PR TITLE
add support for block ranges to eth block cmd

### DIFF
--- a/cmd/eth/balance.go
+++ b/cmd/eth/balance.go
@@ -15,10 +15,12 @@ var cmdbal = &cmd{
 }
 
 var hexbalance bool
+var decbalance bool
 
 func init() {
 	cmdbal.fs.Init("balance", flag.ExitOnError)
 	cmdbal.fs.BoolVar(&hexbalance, "x", false, "print balance in hex")
+	cmdbal.fs.BoolVar(&decbalance, "d", false, "print balance as an integer")
 }
 
 func getbal(args []string) {
@@ -39,6 +41,10 @@ func getbal(args []string) {
 		}
 		if hexbalance {
 			fmt.Println(bal.String())
+			continue
+		} else if decbalance {
+			b := ((big.Int)(bal))
+			fmt.Println(b.String())
 			continue
 		}
 		amt := cc.Amount{"ETH", (big.Int)(bal)}

--- a/cmd/eth/block.go
+++ b/cmd/eth/block.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/newalchemylimited/seth"
 )
@@ -13,16 +14,73 @@ var cmdblock = &cmd{
 	do:   block,
 }
 
+func showblock(b *seth.Block) {
+	buf, err := json.MarshalIndent(b, "", "\t")
+	if err != nil {
+		fatalf("fatal error: %s", err)
+	}
+	fmt.Printf("%s\n", buf)
+}
+
+func blockrange(c *seth.Client, spec string) {
+	var split []string
+	var opstr string
+	for _, sep := range []string{"+", "-"} {
+		if strings.Contains(spec, sep) {
+			split = strings.Split(spec, sep)
+			opstr = sep
+			break
+		}
+	}
+	if len(split) != 2 {
+		fatalf("bad block range specifier %q\n", spec)
+	}
+	var err error
+	var start, diff int64
+	switch split[0] {
+	case "pending":
+		start = pending(c)
+	case "latest":
+		start = latest(c)
+	default:
+		start, err = strconv.ParseInt(split[0], 0, 64)
+		if err != nil {
+			fatalf("couldn't parse %q as an integer: %s\n", split[0], err)
+		}
+	}
+	diff, err = strconv.ParseInt(split[1], 0, 64)
+	if err != nil {
+		fatalf("couldn't parse %q as an integer: %s\n", split[1], err)
+	}
+	op := func(a, b int64) int64 { return a + b }
+	if opstr == "-" {
+		op = func(a, b int64) int64 { return a - b }
+	}
+
+	for i := int64(0); i < diff; i++ {
+		b, err := c.GetBlock(op(start, i), true)
+		if err != nil {
+			fatalf("getting block: %s\n", err)
+		}
+		showblock(b)
+	}
+}
+
 func block(args []string) {
 	if len(args) == 0 {
 		args = append(args, "pending")
 	}
 
 	c := client()
-
 	for i := range args {
 		var bn int64
 		var err error
+
+		if strings.ContainsAny(args[i], "+-") {
+			blockrange(c, args[i])
+			continue
+		}
+
 		switch args[i] {
 		case "pending":
 			bn = seth.Pending
@@ -38,10 +96,6 @@ func block(args []string) {
 		if err != nil {
 			fatalf("getting block %d: %s", bn, err)
 		}
-		buf, err := json.MarshalIndent(b, "", "\t")
-		if err != nil {
-			fatalf("fatal error: %s", err)
-		}
-		fmt.Printf("%s\n", buf)
+		showblock(b)
 	}
 }

--- a/cmd/eth/client.go
+++ b/cmd/eth/client.go
@@ -29,3 +29,20 @@ func client() *seth.Client {
 	os.Exit(1)
 	return nil
 }
+
+func latest(c *seth.Client) int64 {
+	b, err := c.GetBlock(seth.Latest, false)
+	if err != nil {
+		fatalf("getting block: %s\n", err)
+	}
+	return int64(*b.Number)
+}
+
+func pending(c *seth.Client) int64 {
+	b, err := c.GetBlock(seth.Pending, false)
+	if err != nil {
+		fatalf("getting block: %s\n", err)
+	}
+	return int64(*b.Number)
+
+}


### PR DESCRIPTION
Add support for block ranges to `eth block`.

For example, `eth block pending-10` prints the latest 10 blocks, while `eth block 5000000+10` prints block 5 million, plus 9 more blocks (ascending).