### PR TITLE
implement web3 secret storage reading

### DIFF
--- a/keyfile.go
+++ b/keyfile.go
@@ -1,0 +1,163 @@
+package seth
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"strings"
+
+	"github.com/newalchemylimited/seth/keccak"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// Keyfile represents an Ethereum key file
+// as defined in the "Web3 Secret Storage Definition"
+type Keyfile struct {
+	ID      string `json:"id"`
+	Version int    `json:"version"`
+	Crypto  struct {
+		Cipher       string          `json:"cipher"`
+		CipherParams json.RawMessage `json:"cipherparams"`
+		Ciphertext   string          `json:"ciphertext"`
+		KDF          string          `json:"kdf"`
+		KDFParams    json.RawMessage `json:"kdfparams"`
+		MAC          string          `json:"mac"`
+	} `json:"crypto"`
+	Address Address           `json:"address,omitempty"`
+	Name    string            `json:"name"`
+	Meta    map[string]string `json:"meta"`
+}
+
+func (k *Keyfile) ciphertext() ([]byte, error) {
+	return hex.DecodeString(k.Crypto.Ciphertext)
+}
+
+func pbkdf2Derive(pass []byte, jsparams json.RawMessage) ([]byte, error) {
+	type params struct {
+		Iters  int    `json:"c"`
+		Keylen int    `json:"dklen"`
+		Hashfn string `json:"prf"`
+		Salt   string `json:"salt"`
+	}
+	p := new(params)
+	if err := json.Unmarshal(jsparams, p); err != nil {
+		return nil, fmt.Errorf("parsing pbkdf2 params: %q", err)
+	}
+	var h func() hash.Hash
+	switch strings.ToLower(p.Hashfn) {
+	case "hmac-sha512":
+		h = sha512.New
+	case "hmac-sha384":
+		h = sha512.New384
+	case "hmac-sha256":
+		h = sha256.New
+	case "hmac-sha224":
+		h = sha256.New224
+	case "hmac-sha1":
+		h = sha1.New
+	default:
+		return nil, fmt.Errorf("bad prf %q for pbkdf2", p.Hashfn)
+	}
+
+	salt, err := hex.DecodeString(p.Salt)
+	if err != nil {
+		return nil, fmt.Errorf("pbkdf2 salt: %s", err)
+	}
+
+	return pbkdf2.Key(pass, salt, p.Iters, p.Keylen, h), nil
+}
+
+func (k *Keyfile) kdf(pass []byte) ([]byte, error) {
+	switch strings.ToLower(k.Crypto.KDF) {
+	case "pbkdf2":
+		return pbkdf2Derive(pass, k.Crypto.KDFParams)
+	default:
+		return nil, fmt.Errorf("unimplemented KDF %q", k.Crypto.KDF)
+	}
+}
+
+func aes128ctrDecipher(key, ciphertext []byte, jsparams json.RawMessage) error {
+	type params struct {
+		IV string `json:"iv"`
+	}
+	p := new(params)
+	err := json.Unmarshal(jsparams, p)
+	if err != nil {
+		return fmt.Errorf("getting params for aes-128-ctr: %s", err)
+	}
+	iv, err := hex.DecodeString(p.IV)
+	if err != nil {
+		return fmt.Errorf("bad aes-128-ctr iv: %s", err)
+	}
+	block, err := aes.NewCipher(key[:16])
+	if err != nil {
+		return err
+	}
+	stream := cipher.NewCTR(block, iv)
+	stream.XORKeyStream(ciphertext, ciphertext)
+	return nil
+}
+
+// the keyfile MAC is the keccak256 of the last 16 bytes
+// of the derived key, concatenated with the ciphertext
+func (k *Keyfile) checkmac(key, ciphertext []byte) error {
+	h := keccak.New256()
+	h.Write(key[len(key)-16:])
+	h.Write(ciphertext)
+	sum := h.Sum(nil)
+	want, err := hex.DecodeString(k.Crypto.MAC)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(sum, want) {
+		return fmt.Errorf("bad mac %q (bad passphrase?)", k.Crypto.MAC)
+	}
+	return nil
+}
+
+// Private uses a passphrase to unlock a keyfile
+// and produce its private key.
+func (k *Keyfile) Private(passphrase []byte) (*PrivateKey, error) {
+	key, err := k.kdf(passphrase)
+	if err != nil {
+		return nil, err
+	}
+	ciphertext, err := k.ciphertext()
+	if err != nil {
+		return nil, err
+	}
+	err = k.checkmac(key, ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	var decipher func(key, ciphertext []byte, params json.RawMessage) error
+	switch strings.ToLower(k.Crypto.Cipher) {
+	case "aes-128-ctr":
+		decipher = aes128ctrDecipher
+	default:
+		return nil, fmt.Errorf("")
+	}
+
+	err = decipher(key, ciphertext, k.Crypto.CipherParams)
+	if err != nil {
+		return nil, err
+	}
+	priv := new(PrivateKey)
+	copy(priv[:], ciphertext)
+	var zeroaddr Address
+	if k.Address != zeroaddr {
+		addr := priv.Address()
+		if !bytes.Equal(addr[:], k.Address[:]) {
+			return nil, fmt.Errorf("derived address %q; want address %q", addr, &k.Address)
+		}
+	}
+	return priv, nil
+}

--- a/keyfile_test.go
+++ b/keyfile_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 )
 
-// test vector from https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
-const keyfilejson = `{
+func TestKeyfile(t *testing.T) {
+	// test vectors from https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
+	testcases := []string{
+		`{
     "crypto" : {
         "cipher" : "aes-128-ctr",
         "cipherparams" : {
@@ -25,23 +27,45 @@ const keyfilejson = `{
     },
     "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
     "version" : 3
-}`
-
-func TestKeyfile(t *testing.T) {
-	var k Keyfile
-	if err := json.Unmarshal([]byte(keyfilejson), &k); err != nil {
-		t.Fatal(err)
+}`,
+		`{
+    "crypto" : {
+        "cipher" : "aes-128-ctr",
+        "cipherparams" : {
+            "iv" : "83dbcc02d8ccb40e466191a123791e0e"
+        },
+        "ciphertext" : "d172bf743a674da9cdad04534d56926ef8358534d458fffccd4e6ad2fbde479c",
+        "kdf" : "scrypt",
+        "kdfparams" : {
+            "dklen" : 32,
+            "n" : 262144,
+            "r" : 1,
+            "p" : 8,
+            "salt" : "ab0c7876052600dd703518d6fc3fe8984592145b591fc8fb5c6d43190334ba19"
+        },
+        "mac" : "2103ac29920d71da29f15d75b4a16dbe95cfd7ff8faea1056c33131d846e3097"
+    },
+    "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+    "version" : 3
+}`,
 	}
 
-	priv, err := k.Private([]byte("testpassword"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, keyfilejson := range testcases {
+		var k Keyfile
+		if err := json.Unmarshal([]byte(keyfilejson), &k); err != nil {
+			t.Fatal(err)
+		}
 
-	var want Address
-	want.FromString("0x008aeeda4d805471df9b2a5b0f38a0c3bcba786b")
-	addr := priv.Address()
-	if !bytes.Equal(want[:], addr[:]) {
-		t.Fatalf("didn't derive the right address: %x != %x", want[:], addr[:])
+		priv, err := k.Private([]byte("testpassword"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var want Address
+		want.FromString("0x008aeeda4d805471df9b2a5b0f38a0c3bcba786b")
+		addr := priv.Address()
+		if !bytes.Equal(want[:], addr[:]) {
+			t.Fatalf("didn't derive the right address: %x != %x", want[:], addr[:])
+		}
 	}
 }

--- a/keyfile_test.go
+++ b/keyfile_test.go
@@ -1,0 +1,47 @@
+package seth
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// test vector from https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition
+const keyfilejson = `{
+    "crypto" : {
+        "cipher" : "aes-128-ctr",
+        "cipherparams" : {
+            "iv" : "6087dab2f9fdbbfaddc31a909735c1e6"
+        },
+        "ciphertext" : "5318b4d5bcd28de64ee5559e671353e16f075ecae9f99c7a79a38af5f869aa46",
+        "kdf" : "pbkdf2",
+        "kdfparams" : {
+            "c" : 262144,
+            "dklen" : 32,
+            "prf" : "hmac-sha256",
+            "salt" : "ae3cd4e7013836a3df6bd7241b12db061dbe2c6785853cce422d148a624ce0bd"
+        },
+        "mac" : "517ead924a9d0dc3124507e3393d175ce3ff7c1e96529c6c555ce9e51205e9b2"
+    },
+    "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+    "version" : 3
+}`
+
+func TestKeyfile(t *testing.T) {
+	var k Keyfile
+	if err := json.Unmarshal([]byte(keyfilejson), &k); err != nil {
+		t.Fatal(err)
+	}
+
+	priv, err := k.Private([]byte("testpassword"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var want Address
+	want.FromString("0x008aeeda4d805471df9b2a5b0f38a0c3bcba786b")
+	addr := priv.Address()
+	if !bytes.Equal(want[:], addr[:]) {
+		t.Fatalf("didn't derive the right address: %x != %x", want[:], addr[:])
+	}
+}


### PR DESCRIPTION
This allows seth to load keys from Parity/Geth/etc. for use in raw signing.

A future change should probably implement key file generation.