### PR TITLE
add 'eth accounts' command

### DIFF
--- a/cmd/eth/accounts.go
+++ b/cmd/eth/accounts.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+)
+
+var cmdaccounts = &cmd{
+	desc: "show available accounts",
+	do:   accounts,
+}
+
+func accounts(args []string) {
+	kds := keys()
+	for _, kd := range kds {
+		uuid := "none"
+		if kd.kf != nil {
+			uuid = kd.kf.ID
+		}
+		fmt.Println(uuid, kd.addr.String())
+	}
+}

--- a/cmd/eth/client.go
+++ b/cmd/eth/client.go
@@ -11,18 +11,22 @@ import (
 func client() *seth.Client {
 	url := os.Getenv("SETH_URL")
 	if url == "" {
+		debugf("SETH_URL unset; trying to dial local client")
 		return seth.NewClient(seth.IPCDial)
 	}
 	if strings.HasPrefix(url, "http") {
 		var t seth.Transport
 		if strings.Contains(url, "api.infura.io") {
+			debugf("interpreted %q as api.infura.io", url)
 			t = seth.InfuraTransport{}
 		} else {
+			debugf("using http transport %q", url)
 			t = &seth.HTTPTransport{URL: url}
 		}
 		return seth.NewClientTransport(t)
 	}
 	if _, err := os.Stat(url); err == nil {
+		debugf("using IPC path %s", url)
 		return seth.NewClient(seth.IPCPath(url))
 	}
 	fmt.Fprintln(os.Stderr, "cannot derive client from SETH_URL=%q", url)

--- a/cmd/eth/keylist.go
+++ b/cmd/eth/keylist.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 )
 
-var cmdaccounts = &cmd{
-	desc: "show available accounts",
-	do:   accounts,
+var cmdkeylist = &cmd{
+	desc: "show available key files",
+	do:   keylist,
 }
 
-func accounts(args []string) {
+func keylist(args []string) {
 	kds := keys()
 	for _, kd := range kds {
 		uuid := "none"

--- a/cmd/eth/keys.go
+++ b/cmd/eth/keys.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/newalchemylimited/seth"
+)
+
+func home() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	if u, err := user.Current(); err == nil {
+		return u.HomeDir
+	}
+	return ""
+}
+
+// keypaths returns the list of directories
+// in which to look for ethereum key data
+//
+// the default paths may be overridden by
+// specifiying a :-separated KEY_PATH environment variable
+func keypaths() []string {
+	if kp := os.Getenv("KEY_PATH"); kp != "" {
+		return strings.Split(kp, ":")
+	}
+	h := home()
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			filepath.Join(h, "/Library/Application Support/io.parity.ethereum/keys/ethereum/"), // parity
+			filepath.Join(h, "/Library/Ethereum/keystore/"),                                    // geth
+		}
+	case "linux":
+		return []string{
+			filepath.Join(h, ".parity/keys"),       // parity
+			filepath.Join(h, ".ethereum/keystore"), // geth
+		}
+	}
+	return nil
+}
+
+type keydesc struct {
+	path string        // the "path" of the key (which may or may not be a filesystem path)
+	addr seth.Address  // the actual ethereum address
+	kf   *seth.Keyfile // the keyfile, if there is one associated
+}
+
+func keys() []keydesc {
+	var out []keydesc
+	paths := keypaths()
+	for _, p := range paths {
+		p = filepath.Join(p, "*")
+		files, err := filepath.Glob(p)
+		if err != nil {
+			fatalf("getting key files: %s", err)
+		}
+		for _, fp := range files {
+			kf := new(seth.Keyfile)
+			buf, err := ioutil.ReadFile(fp)
+			if err != nil {
+				continue
+			}
+			if err := json.Unmarshal(buf, kf); err == nil &&
+				kf.Address != "" &&
+				kf.ID != "" &&
+				strings.HasSuffix(fp, kf.ID) {
+				kd := keydesc{
+					path: fp,
+					kf:   kf,
+				}
+				kd.addr.FromString("0x" + kf.Address)
+				out = append(out, kd)
+			}
+		}
+	}
+	return out
+}

--- a/cmd/eth/main.go
+++ b/cmd/eth/main.go
@@ -18,10 +18,25 @@ func fatalf(f string, args ...interface{}) {
 	os.Exit(1)
 }
 
+var verbose bool
+
 var subcommands = map[string]*cmd{
 	"balance":  cmdbal,
 	"block":    cmdblock,
 	"accounts": cmdaccounts,
+}
+
+// debugf prints lines prefixed with '+ ' if
+// the -v flag is passed as a flag
+func debugf(f string, args ...interface{}) {
+	if !verbose {
+		return
+	}
+	if len(f) == 0 || f[len(f)-1] != '\n' {
+		f += "\n"
+	}
+	f = "+ " + f
+	fmt.Printf(f, args...)
 }
 
 func usage() {
@@ -48,6 +63,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", args[1])
 		usage()
 	}
+	// every command gets a "-v" flag for debugf output
+	cmd.fs.BoolVar(&verbose, "v", false, "verbose")
 	cmd.fs.Parse(args[2:])
 	cmd.do(cmd.fs.Args())
 }

--- a/cmd/eth/main.go
+++ b/cmd/eth/main.go
@@ -21,9 +21,9 @@ func fatalf(f string, args ...interface{}) {
 var verbose bool
 
 var subcommands = map[string]*cmd{
-	"balance":  cmdbal,
-	"block":    cmdblock,
-	"accounts": cmdaccounts,
+	"balance": cmdbal,
+	"block":   cmdblock,
+	"keys":    cmdkeylist,
 }
 
 // debugf prints lines prefixed with '+ ' if

--- a/cmd/eth/main.go
+++ b/cmd/eth/main.go
@@ -25,27 +25,27 @@ var subcommands = map[string]*cmd{
 }
 
 func usage() {
-	fmt.Fprintln(os.Stdout, "usage: eth <cmd> <args...>")
-	fmt.Fprintln(os.Stdout, "subcommands:")
-	var out []string
+	fmt.Println("usage: eth <cmd> <args...>")
+	fmt.Println("subcommands:")
+	var out [][2]string
 	for name, c := range subcommands {
-		out = append(out, fmt.Sprintf("\t%s\t\t%s", name, c.desc))
+		out = append(out, [2]string{name, c.desc})
 	}
-	sort.Strings(out)
+	sort.Slice(out, func(i, j int) bool { return out[i][0] < out[j][0] })
 	for i := range out {
-		fmt.Fprintln(os.Stdout, out[i])
+		fmt.Printf("%16s    %s\n", out[i][0], out[i][1])
 	}
 	os.Exit(1)
 }
 
 func main() {
 	args := os.Args
-	if len(args) == 1 {
+	if len(args) == 1 || args[1] == "help" {
 		usage()
 	}
 	cmd, ok := subcommands[args[1]]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", args[0])
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", args[1])
 		usage()
 	}
 	cmd.fs.Parse(args[2:])

--- a/cmd/eth/main.go
+++ b/cmd/eth/main.go
@@ -19,8 +19,9 @@ func fatalf(f string, args ...interface{}) {
 }
 
 var subcommands = map[string]*cmd{
-	"balance": cmdbal,
-	"block":   cmdblock,
+	"balance":  cmdbal,
+	"block":    cmdblock,
+	"accounts": cmdaccounts,
 }
 
 func usage() {


### PR DESCRIPTION
Add a command to list addresses stored in key files locally. (By default, it searches in the usual geth and parity locations, but `KEY_PATH` can be used to specify different locations.)

Adding support for enumerating HSM keys should be relatively straightforward; the `keydesc` struct would need to be extended a bit.

Also, some bug fixes on `seth.Keyfile` to deal with parity oddities. (Naturally, the spec is not quite right.)