### PR TITLE
eth sign command

### DIFF
--- a/cmd/eth/main.go
+++ b/cmd/eth/main.go
@@ -24,6 +24,7 @@ var subcommands = map[string]*cmd{
 	"balance": cmdbal,
 	"block":   cmdblock,
 	"keys":    cmdkeylist,
+	"sign":    cmdsign,
 }
 
 // debugf prints lines prefixed with '+ ' if

--- a/cmd/eth/sign.go
+++ b/cmd/eth/sign.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/newalchemylimited/seth"
+)
+
+var cmdsign = &cmd{
+	desc: "sign input",
+	do:   sign,
+}
+
+var signprefix string // prefix to add to signature
+var sighex bool       // output hex
+var hashed bool       // input is already hashed
+
+func init() {
+	cmdsign.fs.StringVar(&signprefix, "prefix", "", "signing prefix")
+	cmdsign.fs.BoolVar(&hashed, "h", false, "input already hashed")
+	cmdsign.fs.BoolVar(&sighex, "x", false, "output is in hex instead of binary")
+}
+
+func sign(args []string) {
+	if len(args) != 1 {
+		fmt.Println("usage: eth sign [-h|-x|-prefix] <infile>")
+		os.Exit(1)
+	}
+	if hashed && signprefix != "" {
+		fatalf("cannot add a prefix to hashed plaintext")
+	}
+
+	f, err := os.Open(args[0])
+	if err != nil {
+		fatalf("cannot sign %s: %s", args[0], err)
+	}
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		fatalf("reading: %s", err)
+	}
+	var h seth.Hash
+	if hashed {
+		if len(buf) != len(h[:]) {
+			fatalf("input length %d is not a keccak256 hash", len(buf))
+		}
+		copy(h[:], buf)
+	} else {
+		if signprefix != "" {
+			buf = append([]byte(signprefix), buf...)
+		}
+		h = seth.HashBytes(buf)
+	}
+
+	fn := signer()
+	sig := fn(&h)
+	if sighex {
+		_, err := io.WriteString(os.Stdout, hex.EncodeToString(sig[:]))
+		if err != nil {
+			fatalf("%s\n", err)
+		}
+	} else {
+		_, err := os.Stdout.Write(sig[:])
+		if err != nil {
+			fatalf("%s\n", err)
+		}
+	}
+	if err := os.Stdout.Close(); err != nil {
+		fatalf("%s\n", err)
+	}
+}


### PR DESCRIPTION
Add a command to use a key (iterated from `eth keys`) to sign the contents of a file.

Was thinking about adding a way to sign stdin, but you have to enter the passphrase, so it's not obvious what that interface would look like.

Sample usage:
```
$ ETHER_ADDR="0x18*" eth sign main.go | od -x
enter key passphrase:
0000000      f99b    ebcf    4490    c305    f657    30bb    913c    8e13
...
```