### PR TITLE
add code and jumptab commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ branches:
 
 before_install:
   - sudo add-apt-repository -y ppa:ethereum/ethereum
+  - sudo add-apt-repository -y ppa:ethereum/ethereum-dev
   - sudo apt-get -y update
   - sudo apt-get -y install solc
   - wget https://developers.yubico.com/YubiHSM2/Releases/yubihsm2-sdk-1.0.1-ubuntu1404-amd64.tar.gz

--- a/cmd/eth/client.go
+++ b/cmd/eth/client.go
@@ -62,3 +62,11 @@ func getblock(c *seth.Client, num int64, txs bool) *seth.Block {
 	}
 	return b
 }
+
+func getcode(c *seth.Client, addr *seth.Address) []byte {
+	code, err := c.GetCode(addr)
+	if err != nil {
+		fatalf("getting code: %s\n", err)
+	}
+	return code
+}

--- a/cmd/eth/code.go
+++ b/cmd/eth/code.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/newalchemylimited/seth"
+)
+
+var cmdcode = &cmd{
+	desc: "get contract code",
+	do:   code,
+}
+
+func code(args []string) {
+	if len(args) != 1 {
+		fatalf("usage: eth code <address>\n")
+	}
+
+	var addr seth.Address
+	if err := addr.FromString(args[0]); err != nil {
+		fatalf("bad address: %s\n", err)
+	}
+	b := getcode(client(), &addr)
+	fmt.Printf("%x\n", b)
+}

--- a/cmd/eth/hsm.go
+++ b/cmd/eth/hsm.go
@@ -21,9 +21,8 @@ func hsmprobe() []seth.HSM {
 				hints = strings.Split(hstr, ",")
 			}
 			h := seth.FindHSM(p, hints...)
-			if h != nil {
-				debugf("probe for hsm %q succeeded", p)
-				hsms = append(hsms, h)
+			if h == nil {
+				continue
 			}
 			var pass []byte
 			if pstr := os.Getenv(strings.ToUpper(p) + "_PASS"); pstr != "" {
@@ -34,6 +33,8 @@ func hsmprobe() []seth.HSM {
 			if err := h.Unlock(pass); err != nil {
 				fatalf("unlock %s: %s", p, err)
 			}
+			debugf("probe for hsm %q succeeded", p)
+			hsms = append(hsms, h)
 		}
 	})
 	return hsms

--- a/cmd/eth/jumptab.go
+++ b/cmd/eth/jumptab.go
@@ -172,7 +172,7 @@ func jumptab(args []string) {
 		if pwidth > 4 {
 			break // ???
 		}
-		copy(pushbytes[:], base[8:8+pwidth])
+		copy(pushbytes[4-pwidth:], base[8:8+pwidth])
 		if base[8+pwidth] != opjumpi {
 			break // ???
 		}
@@ -196,9 +196,9 @@ func jumptab(args []string) {
 		sigword := binary.LittleEndian.Uint32(entries[i].prefix[:])
 		sig := dict[sigword]
 		if sig == "" {
-			fmt.Printf("%x pc:%10d\n", entries[i].prefix[:], entries[i].jmpdest)
+			fmt.Printf("%x pc:%5d\n", entries[i].prefix[:], entries[i].jmpdest)
 		} else {
-			fmt.Printf("%x pc:%10d %s\n", entries[i].prefix[:], entries[i].jmpdest, sig)
+			fmt.Printf("%x pc:%5d %s\n", entries[i].prefix[:], entries[i].jmpdest, sig)
 		}
 	}
 }

--- a/cmd/eth/jumptab.go
+++ b/cmd/eth/jumptab.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/newalchemylimited/seth"
+)
+
+var cmdjumptab = &cmd{
+	desc: "print the jump table of a contract",
+	do:   jumptab,
+}
+
+// just the opcodes we need to parse the jump table
+const (
+	opdup1  = 0x80
+	oppush1 = 0x60
+	opeq    = 0x14
+	opjumpi = 0x57
+)
+
+type jmpentry struct {
+	prefix  [4]byte // jump table prefix
+	jmpdest int     // PC of actual code
+}
+
+// preimage is a list of common function selectors
+var preimage = []string{
+	"balanceOf(address)",
+	"totalSupply()",
+	"transfer(address,uint256)",
+	"transferFrom(address,address,uint256)",
+	"approve(address,uint256)",
+	"changeOwner(address)",
+	"acceptOwnership()",
+	"mint(address,uint256)",
+	"pause()",
+	"finalize()",
+	"name()",
+	"decimals()",
+	"owner()",
+	"finalized()",
+	"allowance(address,address)",
+	"locked()",
+	"burn(address,uint256)",
+}
+
+// code sequences that are equivalent to
+//   (calldata[0] >> 224) & 0xffffffff
+var prefixes = []string{
+	// For some reason, _later_ versions of solc
+	// produce this code, despite the size regression...
+	//
+	// PUSH1 0x0 CALLDATALOAD PUSH29
+	// 0x100000000000000000000000000000000000000000000000000000000
+	// SWAP1 DIV PUSH4 0xFFFFFFFF AND
+	"7c0100000000000000000000000000000000000000000000000000000000900463ffffffff16",
+
+	// PUSH4 0xffffffff
+	// PUSH1 0xe0 PUSH1 0x02 EXP
+	// PUSH1 0x00 CALLDATALOAD
+	// DIV AND
+	"63ffffffff60e060020a6000350416",
+}
+
+type jmpformat struct {
+	prefix, suffix string
+}
+
+func jumptab(args []string) {
+	if len(args) != 1 {
+		fatalf("usage: eth jumptab <address|->\n")
+	}
+	var code []byte
+	if args[0] == "-" {
+		buf, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			fatalf("couldn't read stdin: %s\n", err)
+		}
+		if len(buf) > 1 && buf[len(buf)-1] == '\n' {
+			buf = buf[:len(buf)-1]
+		}
+		code = make([]byte, hex.DecodedLen(len(buf)))
+		_, err = hex.Decode(code, buf)
+		if err != nil {
+			fatalf("couldn't decode input: %s\n", err)
+		}
+	} else {
+		var addr seth.Address
+		err := addr.FromString(args[0])
+		if err != nil {
+			fatalf("jumptab: bad address: %s\n", err)
+		}
+		code = getcode(client(), &addr)
+	}
+	if len(code) == 0 {
+		fatalf("address has no code\n")
+	}
+
+	// for each of the possible jump table preambles,
+	// try to find an appropriate match in the code
+	preamble := -1
+	for _, p := range prefixes {
+		buf, err := hex.DecodeString(p)
+		if err != nil {
+			panic(err)
+		}
+		preamble = bytes.Index(code, buf)
+		if preamble != -1 {
+			preamble = preamble + len(buf)
+			break
+		}
+	}
+	if preamble == -1 {
+		fatalf("couldn't find a jump table preamble\n")
+	}
+
+	// supported jump table formats:
+	//
+	//   DUP1 PUSH4 0x06fdde03 EQ PUSH2 0x0145 JUMPI
+	//
+	//   PUSH4 0x06fdde03 DUP2 EQ PUSH2 0x0145 JUMPI
+	//
+	// TODO: is the PUSH after EQ always PUSH2?
+	// That would make the code a bit simpler.
+	var entries []jmpentry
+	base := code[preamble:]
+	for len(base) > 12 {
+		var pushbytes, prefixbytes [4]byte
+
+		if base[0] == oppush1+3 &&
+			base[5] == opdup1+1 &&
+			base[6] == opeq {
+			// first case: PUSH4 <prefix> DUP2 EQ
+			copy(prefixbytes[:], base[1:4])
+		} else if base[0] == opdup1 &&
+			base[1] == oppush1+3 &&
+			base[6] == opeq {
+			// second case: DUP1 PUSH4 <prefix> EQ
+			copy(prefixbytes[:], base[2:6])
+		} else {
+			break
+		}
+
+		// width of PUSH used to identify PC
+		pwidth := 1 + int(base[7]-oppush1)
+		if pwidth > 4 {
+			break // ???
+		}
+		copy(pushbytes[:], base[8:8+pwidth])
+		if base[8+pwidth] != opjumpi {
+			break // ???
+		}
+		entries = append(entries, jmpentry{
+			prefix:  prefixbytes,
+			jmpdest: int(binary.BigEndian.Uint32(pushbytes[:])),
+		})
+		base = base[8+pwidth+1:]
+	}
+
+	if len(entries) == 0 {
+		return
+	}
+
+	dict := make(map[uint32]string)
+	for _, sig := range preimage {
+		h := seth.HashString(sig)
+		dict[binary.LittleEndian.Uint32(h[:4])] = sig
+	}
+	for i := range entries {
+		sigword := binary.LittleEndian.Uint32(entries[i].prefix[:])
+		sig := dict[sigword]
+		if sig == "" {
+			fmt.Printf("%x pc:%10d\n", entries[i].prefix[:], entries[i].jmpdest)
+		} else {
+			fmt.Printf("%x pc:%10d %s\n", entries[i].prefix[:], entries[i].jmpdest, sig)
+		}
+	}
+}

--- a/cmd/eth/jumptab.go
+++ b/cmd/eth/jumptab.go
@@ -31,45 +31,65 @@ type jmpentry struct {
 
 // preimage is a list of common function selectors
 var preimage = []string{
+	"collect()",
+	"collect(address)",
+	"acceptOwnership()",
+	"allowance(address,address)",
+	"approve(address,uint256)",
+	"approveAndCall(address,uint256,bytes)",
 	"balanceOf(address)",
+	"burn(address,uint256)",
+	"changeOwner(address)",
+	"decimals()",
+	"deposit()",
+	"finalize()",
+	"finalized()",
+	"halt()",
+	"locked()",
+	"makeWallet()",
+	"mint(address,uint256)",
+	"name()",
+	"owner()",
+	"pause()",
+	"setPrice(uint256)",
+	"start()",
+	"sweep(address,uint256)",
+	"symbol()",
+	"tokenFallback(address,uint256,bytes)",
 	"totalSupply()",
 	"transfer(address,uint256)",
 	"transferFrom(address,address,uint256)",
-	"approve(address,uint256)",
-	"changeOwner(address)",
-	"acceptOwnership()",
-	"mint(address,uint256)",
-	"pause()",
-	"finalize()",
-	"name()",
-	"decimals()",
-	"owner()",
-	"finalized()",
-	"allowance(address,address)",
-	"locked()",
-	"burn(address,uint256)",
+	"version()",
 }
 
 // code sequences that are equivalent to
-//   (calldata[0] >> 224) & 0xffffffff
+//   (calldata[0] >> 224)
 var prefixes = []string{
-	// For some reason, _later_ versions of solc
-	// produce this code, despite the size regression...
-	//
 	// PUSH1 0x0 CALLDATALOAD PUSH29
 	// 0x100000000000000000000000000000000000000000000000000000000
 	// SWAP1 DIV PUSH4 0xFFFFFFFF AND
-	"7c0100000000000000000000000000000000000000000000000000000000900463ffffffff16",
+	"6000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16",
+
+	// same as above, with AND produced before instead of after calldata load
+	"63ffffffff6000357c0100000000000000000000000000000000000000000000000000000000900416",
+
+	// ... and another permutation of the above
+	// PUSH4 0xffffffff PUSH29 (1<<224) PUSH1 0x0 CALLDATALOAD DIV AND
+	"63ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416",
+
+	// like the first one, but omitting the superfluous AND
+	"6000357c01000000000000000000000000000000000000000000000000000000009004",
 
 	// PUSH4 0xffffffff
 	// PUSH1 0xe0 PUSH1 0x02 EXP
 	// PUSH1 0x00 CALLDATALOAD
 	// DIV AND
 	"63ffffffff60e060020a6000350416",
-}
 
-type jmpformat struct {
-	prefix, suffix string
+	// same as above, without superflous AND:
+	// PUSH1 0xe0 PUSH1 0x02 EXP
+	// PUSH1 0x00 CALLDATALOAD DIV
+	"60e060020a60003504",
 }
 
 func jumptab(args []string) {

--- a/cmd/eth/main.go
+++ b/cmd/eth/main.go
@@ -25,6 +25,8 @@ var subcommands = map[string]*cmd{
 	"block":   cmdblock,
 	"keys":    cmdkeylist,
 	"sign":    cmdsign,
+	"code":    cmdcode,
+	"jumptab": cmdjumptab,
 }
 
 // debugf prints lines prefixed with '+ ' if
@@ -37,7 +39,7 @@ func debugf(f string, args ...interface{}) {
 		f += "\n"
 	}
 	f = "+ " + f
-	fmt.Printf(f, args...)
+	fmt.Fprintf(os.Stderr, f, args...)
 }
 
 func usage() {


### PR DESCRIPTION
This PR adds two new commands, "code" and "jumptab."

The "code" command just dumps a contract's bytecode (as hex). It was moderately useful while writing the "jumptab" feature.

The "jumptab" command dumps a contract's jump table, along with method signature pre-images (if we know them). It accepts a contracts address, or stdin. (`eth code foo | eth jumptab -` and `eth jumptab foo` are semantically equivalent.)

I've accounted for four different jump table formats I found in the wild. There may be more of them, unfortunately.

For example:
```
bash-3.2$ eth jumptab 0x419d0d8bdd9af5e606ae2232ed285aff190e711b
06fdde00 pc:  325
095ea7b3 pc:  469 approve(address,uint256)
13887592 pc:  520
18160ddd pc:  556 totalSupply()
23b872dd pc:  590 transferFrom(address,address,uint256)
313ce567 pc:  647 decimals()
42966c68 pc:  685
4bb278f3 pc:  706 finalize()
5a53fe20 pc:  724
5aab4ac8 pc:  809
5fe59b9d pc:  953
66188463 pc: 1041
69ffa08a pc: 1092
70a08231 pc: 1146 balanceOf(address)
79ba5097 pc: 1192 acceptOwnership()
870bfc75 pc: 1210
8da5cb5b pc: 1228 owner()
8e339b66 pc: 1272
92eefe9b pc: 1311
95d89b41 pc: 1341 symbol()
9b504387 pc: 1485
a6f9dae1 pc: 1524 changeOwner(address)
a9059cbb pc: 1554 transfer(address,uint256)
b33fcc7a pc: 1605
b3f05b97 pc: 1690 finalized()
d73dd623 pc: 1726
dd62ed3e pc: 1777 allowance(address,address)
```

For something fancier, here's a pipeline for printing the jump table for every contract deployed in the last 10 blocks:
```
eth block pending-10 | jq -r '.transactions[] | select(.creates != null) | .input' | sed 's/0x//g' | while read f; do echo "-------"; echo $f | eth jumptab -; done
```

Also, a curious discovery: `solc` lays out code sorted by function selector.