### PR TITLE
Extra RPC coverage

### DIFF
--- a/personal.go
+++ b/personal.go
@@ -22,9 +22,3 @@ func (c *Client) UnlockAccount(addr *Address, password string) error {
 	}
 	return nil
 }
-
-func (c *Client) Accounts() ([]Address, error) {
-	var out []Address
-	err := c.Do("eth_accounts", []json.RawMessage{}, &out)
-	return out, err
-}

--- a/seth.go
+++ b/seth.go
@@ -441,6 +441,91 @@ type RPCResponse struct {
 	Error   RPCError        `json:"error"`
 }
 
+// ProtocolVersion gets the protocol version of the node.
+func (c *Client) ProtocolVersion() (string, error) {
+	var version string
+	if err := c.Do("eth_protocolVersion", nil, &version); err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
+// SyncStatus indicates the syncing status of the node.
+type SyncStatus struct {
+	Starting Uint64 `json:"startingBlock"` // Starting block of sync.
+	Current  Uint64 `json:"currentBlock"`  // Current block of sync.
+	Highest  Uint64 `json:"highestBlock"`  // Highest block of sync, estimated.
+}
+
+// Syncing returns the syncing status of the node, or nil if not syncing.
+func (c *Client) Syncing() (*SyncStatus, error) {
+	var raw json.RawMessage
+	if err := c.Do("eth_syncing", nil, &raw); err != nil {
+		return nil, err
+	} else if bytes.Equal(raw, rawfalse) {
+		return nil, nil
+	}
+	status := new(SyncStatus)
+	if err := json.Unmarshal(raw, status); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+// Coinbase returns the client coinbase address.
+func (c *Client) Coinbase() (*Address, error) {
+	addr := new(Address)
+	if err := c.Do("eth_coinbase", nil, addr); err != nil {
+		return nil, err
+	}
+	return addr, nil
+}
+
+// Mining returns whether the node is actively mining blocks.
+func (c *Client) Mining() (bool, error) {
+	var mining bool
+	if err := c.Do("eth_mining", nil, &mining); err != nil {
+		return false, err
+	}
+	return mining, nil
+}
+
+// Hashrate gets the number of hashes per second that the node is mining with.
+func (c *Client) Hashrate() (int64, error) {
+	var rate Uint64
+	if err := c.Do("eth_hashrate", nil, &rate); err != nil {
+		return 0, err
+	}
+	return int64(rate), nil
+}
+
+// GasPrice gets the gas price in wei.
+func (c *Client) GasPrice() (int64, error) {
+	var wei Uint64
+	if err := c.Do("eth_gasPrice", nil, &wei); err != nil {
+		return 0, err
+	}
+	return int64(wei), nil
+}
+
+// Accounts gets the accounts owned by the client.
+func (c *Client) Accounts() ([]Address, error) {
+	var out []Address
+	if err := c.Do("eth_accounts", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// BlockNumber gets the number of the most recent block.
+func (c *Client) BlockNumber() (int64, error) {
+	var block Uint64
+	if err := c.Do("eth_blockNumber", nil, &block); err != nil {
+		return 0, err
+	}
+	return int64(block), nil
+}
+
 // Pending returns the list of pending transactions.
 func (c *Client) Pending() ([]Transaction, error) {
 	b, err := c.GetBlock(-1, true)

--- a/seth_test.go
+++ b/seth_test.go
@@ -231,3 +231,29 @@ func TestGetNonce(t *testing.T) {
 		}
 	}
 }
+
+func TestGasPrice(t *testing.T) {
+	t.Parallel()
+
+	client := NewHTTPClient("https://api.myetherapi.com/eth")
+
+	if wei, err := client.GasPrice(); err != nil {
+		t.Fatal(err)
+	} else if wei <= 0 {
+		t.Fatal("gas price is too low:", wei)
+	}
+}
+
+func TestBlockNumber(t *testing.T) {
+	t.Parallel()
+
+	client := NewHTTPClient("https://api.myetherapi.com/eth")
+
+	const min = 5132536 // Block number at time test was added.
+
+	if block, err := client.BlockNumber(); err != nil {
+		t.Fatal(err)
+	} else if block < min {
+		t.Fatal("block number is too low:", block, "<", min)
+	}
+}

--- a/tevm/evm_test.go
+++ b/tevm/evm_test.go
@@ -115,6 +115,36 @@ func TestChainBasic(t *testing.T) {
 	please(t, c.BalanceOf(&dumb).Int64() == 1e18)
 }
 
+// TestTransportBasic tests transport RPCs that aren't covered elsewhere.
+func TestTransportBasic(t *testing.T) {
+	chain := NewChain()
+	client := seth.NewClientTransport(chain)
+
+	// eth_protocolVersion
+	if _, err := client.ProtocolVersion(); err != nil {
+		t.Error(err)
+	}
+
+	// eth_syncing
+	if _, err := client.Syncing(); err != nil {
+		t.Error(err)
+	}
+
+	// eth_gasPrice
+	if p, err := client.GasPrice(); err != nil {
+		t.Error(err)
+	} else if p == 0 {
+		t.Fatal("gas price should be > 0")
+	}
+
+	// eth_blockNumber
+	if n, err := client.BlockNumber(); err != nil {
+		t.Error(err)
+	} else if n == 0 {
+		t.Fatal("block number should be > 0")
+	}
+}
+
 // Test that a chain can be JSON marshaled and recovered.
 func TestChainSerialization(t *testing.T) {
 	t.Parallel()

--- a/tevm/transport.go
+++ b/tevm/transport.go
@@ -89,10 +89,6 @@ func (c *Chain) Execute(req *seth.RPCRequest, res *seth.RPCResponse) error {
 	res.ID = req.ID
 	res.Version = req.Version
 
-	if len(req.Params) == 0 {
-		return errors.New(req.Method + ": not enough params")
-	}
-
 	if c.Debugf != nil {
 		c.Debugf("request:\n%s\n", pretty(req))
 	}
@@ -102,7 +98,7 @@ func (c *Chain) Execute(req *seth.RPCRequest, res *seth.RPCResponse) error {
 	c.mu.Unlock()
 	if err != nil {
 		res.Result = nil
-		res.Error.Code = -1 // FIXME
+		res.Error.Code = -32601
 		res.Error.Message = err.Error()
 		res.Error.Data = nil
 		err = nil
@@ -119,6 +115,26 @@ func (c *Chain) Execute(req *seth.RPCRequest, res *seth.RPCResponse) error {
 func (c *Chain) execute(method string, params []json.RawMessage) (interface{}, error) {
 	var b blocknum
 	switch method {
+	case "eth_protocolVersion":
+		if err := marshal(params); err != nil {
+			return nil, err
+		}
+		return seth.Uint64(63), nil
+	case "eth_syncing":
+		if err := marshal(params); err != nil {
+			return nil, err
+		}
+		return false, nil
+	case "eth_gasPrice":
+		if err := marshal(params); err != nil {
+			return nil, err
+		}
+		return seth.Uint64(16e9), nil
+	case "eth_blockNumber":
+		if err := marshal(params); err != nil {
+			return nil, err
+		}
+		return c.State.Pending.Number, nil
 	case "eth_call":
 		tx := new(callArgs)
 		if err := marshal(params, tx, &b); err != nil {


### PR DESCRIPTION
Adds support for these RPCs:

* eth_protocolVersion
* eth_syncing
* eth_coinbase
* eth_mining
* eth_hashrate
* eth_gasPrice
* eth_blockNumber

Most of them are just for local RPC nodes and are mostly there for completeness, but gas price and block number are useful.

There are a few others I want to add, I'm just putting these out there. We might want to merge these for now, because I found myself wanting eth_blockNumber earlier, but I don't really mind either way.