### PR TITLE
Add "eth recover" command

### DIFF
--- a/cmd/eth/hsm.go
+++ b/cmd/eth/hsm.go
@@ -28,7 +28,7 @@ func hsmprobe() []seth.HSM {
 			if pstr := os.Getenv(strings.ToUpper(p) + "_PASS"); pstr != "" {
 				pass = []byte(pstr)
 			} else {
-				pass = passpromptf("enter HSM pasword for %s:\n", p)
+				pass = passpromptf("enter HSM password for %s:\n", p)
 			}
 			if err := h.Unlock(pass); err != nil {
 				fatalf("unlock %s: %s", p, err)

--- a/cmd/eth/keys.go
+++ b/cmd/eth/keys.go
@@ -88,7 +88,11 @@ func keys() []keydesc {
 				debugf("keyfile scan: file %q doesn't look like json", fp)
 				continue
 			}
-			if err := json.Unmarshal(buf, kf); err == nil && kfvalid(kf) {
+			if err := json.Unmarshal(buf, kf); err != nil {
+				debugf("keyfile scan: failed to parse file %q: %s", fp, err)
+				continue
+			}
+			if kfvalid(kf) {
 				debugf("using keyfile %q", fp)
 				kd := keydesc{
 					path: fp,

--- a/cmd/eth/main.go
+++ b/cmd/eth/main.go
@@ -13,7 +13,15 @@ type cmd struct {
 	fs   flag.FlagSet
 }
 
+func fatal(args ...interface{}) {
+	fmt.Fprintln(os.Stderr, args...)
+	os.Exit(1)
+}
+
 func fatalf(f string, args ...interface{}) {
+	if len(f) == 0 || f[len(f)-1] != '\n' {
+		f += "\n"
+	}
 	fmt.Fprintf(os.Stderr, f, args...)
 	os.Exit(1)
 }
@@ -23,12 +31,13 @@ var verbose bool
 var subcommands = map[string]*cmd{
 	"balance": cmdbal,
 	"block":   cmdblock,
-	"keys":    cmdkeylist,
-	"sign":    cmdsign,
 	"code":    cmdcode,
 	"jumptab": cmdjumptab,
-	"post":    cmdpost,
 	"keygen":  cmdkeygen,
+	"keys":    cmdkeylist,
+	"post":    cmdpost,
+	"recover": cmdrecover,
+	"sign":    cmdsign,
 }
 
 // debugf prints lines prefixed with '+ ' if

--- a/cmd/eth/recover.go
+++ b/cmd/eth/recover.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/newalchemylimited/seth"
+)
+
+var cmdrecover = &cmd{
+	desc: "recover the address from a signature",
+	do:   ecrecover,
+}
+
+var ecrpub bool // print public key
+
+func init() {
+	cmdrecover.fs.BoolVar(&ecrpub, "pub", false, "print public key")
+}
+
+func ecrecover(args []string) {
+	if len(args) < 1 || len(args) > 2 {
+		fmt.Println("usage: eth recover [-pub] <sig> [hash]")
+		os.Exit(1)
+	}
+
+	sig, err := seth.ParseSignature(args[0])
+	if err != nil {
+		fatal("signature:", err)
+	}
+
+	var hash seth.Hash
+
+	if len(args) == 1 {
+		b, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			fatal("failed reading:", err)
+		}
+		hash = seth.HashBytes(b)
+	} else if err := hash.FromString(args[1]); err != nil {
+		fatal("hash:", err)
+	}
+
+	pk, err := sig.Recover(&hash)
+	if err != nil {
+		fatal("recover:", err)
+	}
+
+	if ecrpub {
+		fmt.Println(pk)
+	} else {
+		fmt.Println(pk.Address())
+	}
+}


### PR DESCRIPTION
This either takes a hex hash as an argument or hashes data from standard input. Not sure that's the most intuitive interface, but presumably we'll be revisiting everything in here to make it more consistent at some point.