### PR TITLE
RLP refactor and signer in sender

### DIFF
--- a/cmd/eth/keys.go
+++ b/cmd/eth/keys.go
@@ -171,7 +171,7 @@ func signer() seth.Signer {
 		if err != nil {
 			fatalf("couldn't derive private key: %s\n", err)
 		}
-		return seth.KeySigner(priv)
+		return priv.Signer()
 	}
 
 	// hsm signer

--- a/send.go
+++ b/send.go
@@ -140,6 +140,22 @@ type CallOpts struct {
 	Nonce    Uint64   `json:"nonce,omitempty"`    // Nonce of the call
 }
 
+// Transaction returns a transaction structure representing this call.
+func (o *CallOpts) Transaction() *Transaction {
+	tx := &Transaction{
+		From:     o.From,
+		To:       o.To,
+		Gas:      Uint64(o.Gas.Uint64()),
+		GasPrice: *o.GasPrice,
+		Input:    o.Data,
+		Nonce:    o.Nonce,
+	}
+	if o.Value != nil {
+		tx.Value = *o.Value
+	}
+	return tx
+}
+
 const illegal = " \t\n\b-+/~!@#$%^&*=|;:\"<>\\?"
 
 // check that the given arguments correspond

--- a/seth.go
+++ b/seth.go
@@ -399,21 +399,6 @@ func (b *Block) ParseTransactions() ([]Transaction, error) {
 	return out, nil
 }
 
-// Transaction represents an ethereum transaction
-type Transaction struct {
-	Hash        Hash     `json:"hash"`             // tx hash
-	Nonce       Uint64   `json:"nonce"`            // sender nonce
-	Block       Hash     `json:"blockHash"`        // hash of parent block
-	BlockNumber Uint64   `json:"blockNumber"`      //
-	To          *Address `json:"to"`               // receiver, or nil for contract creation
-	TxIndex     *Uint64  `json:"transactionIndex"` // transaction index, or nil if pending
-	From        *Address `json:"from"`             // from
-	Value       Int      `json:"value"`            // value in wei
-	GasPrice    Int      `json:"gasPrice"`         // gas price
-	Gas         Uint64   `json:"gas"`              // gas spent on transaction
-	Input       Data     `json:"input"`            // input data
-}
-
 // RPCRequest is a request to be sent to an RPC server.
 type RPCRequest struct {
 	Version string            `json:"jsonrpc"`

--- a/signature.go
+++ b/signature.go
@@ -235,6 +235,13 @@ func (k *PrivateKey) Sign(hash *Hash) *Signature {
 	}
 }
 
+// Signer returns a Signer for this private key.
+func (k *PrivateKey) Signer() Signer {
+	return func(h *Hash) (*Signature, error) {
+		return k.Sign(h), nil
+	}
+}
+
 // ParsePrivateKey parses a private key.
 func ParsePrivateKey(s string) (*PrivateKey, error) {
 	k := new(PrivateKey)

--- a/transaction.go
+++ b/transaction.go
@@ -2,10 +2,66 @@ package seth
 
 import (
 	"bytes"
-	"io"
 )
 
-func intBytes(n Uint64) []byte {
+// Transaction represents an ethereum transaction.
+type Transaction struct {
+	Hash        Hash     `json:"hash"`             // tx hash
+	Nonce       Uint64   `json:"nonce"`            // sender nonce
+	Block       Hash     `json:"blockHash"`        // hash of parent block
+	BlockNumber Uint64   `json:"blockNumber"`      //
+	To          *Address `json:"to"`               // receiver, or nil for contract creation
+	TxIndex     *Uint64  `json:"transactionIndex"` // transaction index, or nil if pending
+	From        *Address `json:"from"`             // from
+	Value       Int      `json:"value"`            // value in wei
+	GasPrice    Int      `json:"gasPrice"`         // gas price
+	Gas         Uint64   `json:"gas"`              // gas spent on transaction
+	Input       Data     `json:"input"`            // input data
+}
+
+// Encode returns an RLP encoded representation of the transaction. If a
+// signature is provided, this will return an encoded representation containing
+// the signature.
+func (t *Transaction) Encode(sig *Signature) []byte {
+	var e rlpEncoder
+	if sig == nil {
+		e.EncodeTransaction(t)
+	} else {
+		e.EncodeSignedTx(t, sig)
+	}
+	return e.Bytes()
+}
+
+// HashToSign returns a hash which can be used to sign the transaction.
+func (t *Transaction) HashToSign() *Hash {
+	var data, res rlpEncoder
+
+	data.EncodeTransaction(t)
+	data.EncodeInt(1)
+	data.EncodeInt(0)
+	data.EncodeInt(0)
+
+	res.EncodeList(data.Bytes())
+
+	hash := HashBytes(res.Bytes())
+
+	return &hash
+}
+
+// An rlpEncoder is a byte buffer that can RLP encode values.
+type rlpEncoder bytes.Buffer
+
+// Write proxies to bytes.Buffer.Write.
+func (e *rlpEncoder) Write(b []byte) (n int, err error) {
+	return (*bytes.Buffer)(e).Write(b)
+}
+
+// Bytes proxies to bytes.Buffer.Bytes.
+func (e *rlpEncoder) Bytes() []byte {
+	return (*bytes.Buffer)(e).Bytes()
+}
+
+func intBytes(n uint64) []byte {
 	var buf bytes.Buffer
 	shift := uint64(0)
 
@@ -21,108 +77,95 @@ func intBytes(n Uint64) []byte {
 	return buf.Bytes()
 }
 
-func rlpEncodeInt(w io.Writer, n Uint64) {
+// EncodeInt encodes an int.
+func (e *rlpEncoder) EncodeInt(n uint64) {
 	if n == 0 {
-		w.Write([]byte{0x80})
+		e.Write([]byte{0x80})
 	} else {
-		encodeBytes(w, intBytes(n), 0x80, 0xB7)
+		e.EncodeBytes(intBytes(n), 0x80, 0xB7)
 	}
-	return
 }
 
-func rlpEncodeString(w io.Writer, b []byte) {
-	if bytes.Equal(b, []byte("")) {
-		w.Write([]byte{0x80})
+// EncodeString encodes a string.
+func (e *rlpEncoder) EncodeString(b []byte) {
+	if len(b) == 0 {
+		e.Write([]byte{0x80})
 	} else if bytes.Equal(b, []byte{0x00}) {
-		w.Write([]byte{0x00})
+		e.Write([]byte{0x00})
 	} else {
-		encodeBytes(w, b, 0x80, 0xB7)
+		e.EncodeBytes(b, 0x80, 0xB7)
 	}
-	return
 }
 
-func rlpEncodeList(w io.Writer, b []byte) {
+// EncodeList encodes a list of bytes.
+func (e *rlpEncoder) EncodeList(b []byte) {
 	if len(b) == 1 && b[0] == 0x00 {
-		w.Write([]byte{0x80})
+		e.Write([]byte{0x80})
 	} else {
-		encodeBytes(w, b, 0xC0, 0xF7)
+		e.EncodeBytes(b, 0xC0, 0xF7)
 	}
-	return
 }
 
-func encodeBytes(w io.Writer, b []byte, sh byte, lh byte) {
+// EncodeBytes encodes bytes using sh or lh as headers depending on len(b).
+func (e *rlpEncoder) EncodeBytes(b []byte, sh byte, lh byte) {
 	if len(b) == 1 && b[0] < 0x80 {
-		w.Write(b)
+		e.Write(b)
 		return
 	}
 
 	if len(b) < 56 {
-		w.Write([]byte{byte(int(sh) + len(b))})
+		e.Write([]byte{byte(int(sh) + len(b))})
 	} else {
-		blen := intBytes(Uint64(len(b)))
-		w.Write([]byte{byte(int(lh) + len(blen))})
-		w.Write(blen)
+		blen := intBytes(uint64(len(b)))
+		e.Write([]byte{byte(int(lh) + len(blen))})
+		e.Write(blen)
 	}
 
-	w.Write(b)
-	return
+	e.Write(b)
 }
 
-func encodeTransaction(w io.Writer, t *Transaction) {
-	rlpEncodeInt(w, t.Nonce)
-	rlpEncodeString(w, t.GasPrice.Big().Bytes())
-	rlpEncodeInt(w, t.Gas)
+// EncodeTransaction encodes the given transaction.
+func (e *rlpEncoder) EncodeTransaction(t *Transaction) {
+	e.EncodeInt(uint64(t.Nonce))
+	e.EncodeString(t.GasPrice.Big().Bytes())
+	e.EncodeInt(uint64(t.Gas))
 
 	if t.To == nil {
-		rlpEncodeString(w, []byte(""))
+		e.EncodeString(nil)
 	} else {
-		rlpEncodeString(w, t.To[:])
+		e.EncodeString(t.To[:])
 	}
 
-	rlpEncodeString(w, t.Value.Big().Bytes())
-	rlpEncodeString(w, t.Input)
+	e.EncodeString(t.Value.Big().Bytes())
+	e.EncodeString(t.Input)
 
 	return
 }
 
-func rlpEncodeSignedTx(t *Transaction, sig *Signature) []byte {
-	var res, buf bytes.Buffer
-	encodeTransaction(&buf, t)
+// EncodeSignedTx encodes a transaction with the given signature.
+func (e *rlpEncoder) EncodeSignedTx(t *Transaction, sig *Signature) {
+	var buf rlpEncoder
+	buf.EncodeTransaction(t)
 
 	r, s, v := sig.Parts()
 
-	rlpEncodeInt(&buf, Uint64(v)+37)
-	rlpEncodeString(&buf, r.Bytes())
-	rlpEncodeString(&buf, s.Bytes())
+	buf.EncodeInt(uint64(v) + 37)
+	buf.EncodeString(r.Bytes())
+	buf.EncodeString(s.Bytes())
 
-	rlpEncodeList(&res, buf.Bytes())
-	return res.Bytes()
+	e.EncodeList(buf.Bytes())
 }
 
+// A Signer is a function capable of signing a hash.
 type Signer func(*Hash) (*Signature, error)
-
-// KeySigner is sugar that returns a Signer from a PrivateKey.
-func KeySigner(k *PrivateKey) Signer {
-	return func(h *Hash) (*Signature, error) {
-		return k.Sign(h), nil
-	}
-}
 
 // SignTransaction produces a signed, serialized 'raw' transaction
 // from the given transaction and signer.
 func SignTransaction(t *Transaction, sign Signer) ([]byte, error) {
-	var data, res bytes.Buffer
-	encodeTransaction(&data, t)
-	rlpEncodeInt(&data, 1)
-	rlpEncodeInt(&data, 0)
-	rlpEncodeInt(&data, 0)
-
-	rlpEncodeList(&res, data.Bytes())
-
-	hash := HashBytes(res.Bytes())
-	sig, err := sign(&hash)
+	hash := t.HashToSign()
+	sig, err := sign(hash)
 	if err != nil {
 		return nil, err
 	}
-	return rlpEncodeSignedTx(t, sig), nil
+	return t.Encode(sig), nil
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -37,9 +36,9 @@ var encodeIntTests = []encodeTest{
 	{input: uint64(0xFFFFFFFF), output: "84FFFFFFFF"},
 }
 
-func runEncTests(t *testing.T, d []encodeTest, f func(w io.Writer, val interface{})) {
+func runEncTests(t *testing.T, d []encodeTest, f func(e *rlpEncoder, val interface{})) {
 	for i, test := range d {
-		res := new(bytes.Buffer)
+		res := new(rlpEncoder)
 
 		f(res, test.input)
 
@@ -51,9 +50,8 @@ func runEncTests(t *testing.T, d []encodeTest, f func(w io.Writer, val interface
 }
 
 func TestEncodeInt(t *testing.T) {
-	runEncTests(t, encodeIntTests, func(w io.Writer, val interface{}) {
-		rlpEncodeInt(w, Uint64(val.(uint64)))
-		return
+	runEncTests(t, encodeIntTests, func(e *rlpEncoder, val interface{}) {
+		e.EncodeInt(val.(uint64))
 	})
 }
 
@@ -94,9 +92,8 @@ var encodeBytesTests = []encodeTest{
 }
 
 func TestEncodeBytes(t *testing.T) {
-	runEncTests(t, encodeBytesTests, func(w io.Writer, val interface{}) {
-		rlpEncodeString(w, val.([]byte))
-		return
+	runEncTests(t, encodeBytesTests, func(e *rlpEncoder, val interface{}) {
+		e.EncodeString(val.([]byte))
 	})
 }
 
@@ -172,7 +169,7 @@ func signedTx(t *testing.T, p string) {
 func TestSignedTxMarshal(t *testing.T) {
 	signedTx(t, "./_test/txs/*.json")
 
-	runEncTests(t, signedTxTests, func(w io.Writer, val interface{}) {
+	runEncTests(t, signedTxTests, func(e *rlpEncoder, val interface{}) {
 		tx := val.(sTx)
 		res, err := SignTransaction(tx.t, func(*Hash) (*Signature, error) {
 			return tx.s, nil
@@ -181,7 +178,7 @@ func TestSignedTxMarshal(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		w.Write(res)
+		e.Write(res)
 		return
 	})
 }


### PR DESCRIPTION
This adds a Signer field to the Sender type. If specified, this causes Sender to send using eth_sendRawTransaction. This also pushes some symbols around in the signing code.