### PR TITLE
choose a nonce in Call if none is provided

### DIFF
--- a/keyfile.go
+++ b/keyfile.go
@@ -188,6 +188,10 @@ func (k *Keyfile) Private(passphrase []byte) (*PrivateKey, error) {
 	return priv, nil
 }
 
+// ToKeyfile produces a Keyfile for p with the given name and password.
+// The Keyfile is produced using the strongest available parameters, which,
+// as of this writing, are aes-128-ctr encryption and scrypt-based key-derivation.
+// Pass Name may be "". For privacy reasons, ToKeyfile doesn't set Keyfile.Address.
 func (p *PrivateKey) ToKeyfile(name string, pass []byte) *Keyfile {
 	kf := &Keyfile{
 		Version: 3,

--- a/send.go
+++ b/send.go
@@ -137,7 +137,7 @@ type CallOpts struct {
 	GasPrice *Int     `json:"gasPrice,omitempty"` // GasPrice offered for gas
 	Value    *Int     `json:"value,omitempty"`    // Value to send
 	Data     Data     `json:"data"`               // Input to the call
-	Nonce    Uint64   `json:"nonce,omitempty"`    // Nonce of the call
+	Nonce    *Uint64  `json:"nonce,omitempty"`    // Nonce of the call
 }
 
 // Transaction returns a transaction structure representing this call.
@@ -148,10 +148,12 @@ func (o *CallOpts) Transaction() *Transaction {
 		Gas:      Uint64(o.Gas.Uint64()),
 		GasPrice: *o.GasPrice,
 		Input:    o.Data,
-		Nonce:    o.Nonce,
 	}
 	if o.Value != nil {
 		tx.Value = *o.Value
+	}
+	if o.Nonce != nil {
+		tx.Nonce = *o.Nonce
 	}
 	return tx
 }

--- a/tevm/evm.go
+++ b/tevm/evm.go
@@ -62,7 +62,6 @@ var theconfig = vm.Config{
 	ForceJit:                false,
 	Tracer:                  nil,
 	NoRecursion:             false,
-	DisableGasMetering:      false,
 	EnablePreimageRecording: false,
 }
 


### PR DESCRIPTION
Before we had implemented signing, we just let the JSON-RPC server select a nonce if none was provided. We can't do that with in-process signing, so we use `GetNonceAt` to fill the nonce field. (This is, unfortunately, racy, but it's not clear there's a better alternative.)